### PR TITLE
Unit sql

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,8 +56,25 @@ jobs:
         run: docker compose down -v
         continue-on-error: true
       
-      - name: Start web stack for Playwright shard
-        run: docker compose --profile test up --build -d db web-test
+      - name: Start web stack for Playwright shard (retry on transient pull/build failures)
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            echo "Starting Playwright stack (attempt ${attempt}/3)"
+            if docker compose --profile test up --build -d db web-test; then
+              exit 0
+            fi
+
+            if [[ "$attempt" -lt 3 ]]; then
+              echo "Compose startup failed, retrying in 20s..."
+              docker compose down -v --remove-orphans || true
+              sleep 20
+            fi
+          done
+
+          echo "Compose startup failed after 3 attempts"
+          exit 1
 
       - name: Run Playwright shard
         run: docker compose --profile test run --rm test npx playwright test --shard=${{ matrix.shard }}/4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,10 @@ jobs:
 
       - name: Run unit tests
         run: pytest tests/unit/ -v -n auto --dist=loadscope --cov=backend --cov-report=xml --cov-report=term
+        env:
+          DATABASE_URL: sqlite+aiosqlite:///:memory:
+          AUTO_INIT_DB: "false"
+          TEST_MODE: "true"
       
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Pause before unit tests
+        run: sleep 30
+
       - name: Run unit tests
         run: pytest tests/unit/ -v -n auto --dist=loadscope --cov=backend --cov-report=xml --cov-report=term
       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Pause before unit tests
-        run: sleep 45
-
       - name: Run unit tests
         run: pytest tests/unit/ -v -n auto --dist=loadscope --cov=backend --cov-report=xml --cov-report=term
       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Pause before unit tests
-        run: sleep 30
+        run: sleep 45
 
       - name: Run unit tests
         run: pytest tests/unit/ -v -n auto --dist=loadscope --cov=backend --cov-report=xml --cov-report=term

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run unit tests
         run: pytest tests/unit/ -v -n auto --dist=loadscope --cov=backend --cov-report=xml --cov-report=term
         env:
-          DATABASE_URL: sqlite+aiosqlite:///:memory:
+          DATABASE_URL: "sqlite+aiosqlite:///:memory:"
           AUTO_INIT_DB: "false"
           TEST_MODE: "true"
       

--- a/README.md
+++ b/README.md
@@ -101,4 +101,3 @@ Instructor:
 
 Project logo made by [Victoria Khoreva](https://www.instagram.com/victheliar/):
 ![Parsons code lab logo](ohtuproj_logo.png)
-test

--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ Instructor:
 
 Project logo made by [Victoria Khoreva](https://www.instagram.com/victheliar/):
 ![Parsons code lab logo](ohtuproj_logo.png)
+hello

--- a/README.md
+++ b/README.md
@@ -101,4 +101,3 @@ Instructor:
 
 Project logo made by [Victoria Khoreva](https://www.instagram.com/victheliar/):
 ![Parsons code lab logo](ohtuproj_logo.png)
-hello

--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ Instructor:
 
 Project logo made by [Victoria Khoreva](https://www.instagram.com/victheliar/):
 ![Parsons code lab logo](ohtuproj_logo.png)
+test

--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ Instructor:
 
 Project logo made by [Victoria Khoreva](https://www.instagram.com/victheliar/):
 ![Parsons code lab logo](ohtuproj_logo.png)
+more

--- a/README.md
+++ b/README.md
@@ -101,4 +101,3 @@ Instructor:
 
 Project logo made by [Victoria Khoreva](https://www.instagram.com/victheliar/):
 ![Parsons code lab logo](ohtuproj_logo.png)
-more

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -90,9 +90,9 @@ async def client(db_session):
     app.dependency_overrides[get_db] = override_get_db
 
     async with AsyncClient(
-        # Keep unit tests deterministic: don't run app lifespan startup hooks
-        # (init/seed) that use the global DB session.
-        transport=ASGITransport(app=app, lifespan="off"),
+        # Keep unit tests deterministic: with this httpx transport setup,
+        # app lifespan startup hooks are not executed.
+        transport=ASGITransport(app=app),
         base_url="http://test"
     ) as ac:
         yield ac

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -90,8 +90,6 @@ async def client(db_session):
     app.dependency_overrides[get_db] = override_get_db
 
     async with AsyncClient(
-        # Keep unit tests deterministic: with this httpx transport setup,
-        # app lifespan startup hooks are not executed.
         transport=ASGITransport(app=app),
         base_url="http://test"
     ) as ac:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,6 +10,12 @@ from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.pool import StaticPool
 from httpx import AsyncClient, ASGITransport
 
+# Hard-pin unit tests to an isolated SQLite DB so they can never hit the
+# Playwright/Postgres database, regardless of outer environment.
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
+os.environ["AUTO_INIT_DB"] = "false"
+os.environ["TEST_MODE"] = "true"
+
 # Handle different SQLAlchemy versions
 try:
     from sqlalchemy.ext.asyncio import async_sessionmaker
@@ -27,6 +33,16 @@ import sys
 # Allow legacy `import utils` used by some tests to continue working by
 # aliasing `backend.utils` as `utils` in sys.modules for the test run.
 sys.modules.setdefault('utils', importlib.import_module('backend.utils'))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _assert_unit_tests_use_sqlite() -> None:
+    """Safety check: prevent unit tests from ever using Postgres test DB."""
+    from backend import database as db_module
+
+    assert db_module.DATABASE_URL.startswith("sqlite+aiosqlite://"), (
+        f"Unit tests must use SQLite, got DATABASE_URL={db_module.DATABASE_URL!r}"
+    )
 
 
 @pytest_asyncio.fixture
@@ -74,7 +90,9 @@ async def client(db_session):
     app.dependency_overrides[get_db] = override_get_db
 
     async with AsyncClient(
-        transport=ASGITransport(app=app),
+        # Keep unit tests deterministic: don't run app lifespan startup hooks
+        # (init/seed) that use the global DB session.
+        transport=ASGITransport(app=app, lifespan="off"),
         base_url="http://test"
     ) as ac:
         yield ac


### PR DESCRIPTION
Fix random CI failing by adding checks to ensure that unit tests always use the sqlite database and never interfere with Playwright tests.